### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,6 +6,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/1maiprogram/website/security/code-scanning/2](https://github.com/1maiprogram/website/security/code-scanning/2)

The best way to fix the problem is to explicitly set the minimal necessary permissions by adding a `permissions` block to your workflow file. Since the current workflow only checks out source code and runs local scripts (i.e., it does not require writing to the repository, opening PRs, or publishing packages), only read access to repository contents is required. Therefore, you should add `permissions: contents: read` at the workflow root (just after the `name:` and before `on:`), which will apply to all jobs in the workflow. No additional imports or code changes are necessary.

**Files/regions/lines to change:**  
- File: `.github/workflows/node.js.yml`
- Add the following block:
  ```yaml
  permissions:
    contents: read
  ```
  immediately after the `name: Node.js CI` line (line 8), and before `on:` (line 10).


---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
