### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@
 # This workflow will deploy to www.1maiprogram.no.
 
 name: Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/1maiprogram/website/security/code-scanning/1](https://github.com/1maiprogram/website/security/code-scanning/1)

To fix the problem, explicitly specify minimum required GitHub token permissions using a `permissions` block. The best way here is to add `permissions: contents: read` at the root of the workflow, making it apply to all contained jobs (there is only one job here). This grants the workflow read-only access to repository contents, which suffices for checking out the code (`actions/checkout`), while preventing unnecessary write access. Edit `.github/workflows/deploy.yml` by inserting the following lines:

```yaml
permissions:
  contents: read
```
after the `name: Deploy` line (line 7), and before the `on:` trigger. No other imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
